### PR TITLE
Fix NullPointerException in gnu.text.CharMap

### DIFF
--- a/gnu/text/Char.java
+++ b/gnu/text/Char.java
@@ -280,7 +280,7 @@ class CharMap extends AbstractWeakHashTable<Char,Char>
 	 node != null;  node = node.next)
       {
         Char val = node.getValue();
-        if (val.intValue() == key)
+        if (val != null && val.intValue() == key)
           return val;
       }
     Char val = new Char(key);


### PR DESCRIPTION
AbstractWeakHashTable.WEntry.getValue() calls WeakReference.get(),
which will return null if its referent has been GCed. CharMap doesn't
test whether the result of this call is null, so in rare instances a
NullPointerException is thrown when operating over Chars.

This commit adds a check whether the returned value is null before
attempting to deference it to prevent the NPE from occurring.